### PR TITLE
fix: Removed deprecated function

### DIFF
--- a/arith/bin/main.ml
+++ b/arith/bin/main.ml
@@ -109,9 +109,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
-    try main();0 
-    with Exit x -> x) 
-  ()
+    try main(); 0 
+    with Exit x -> x 
 let () = print_flush()
 let () = exit res

--- a/bot/bin/main.ml
+++ b/bot/bin/main.ml
@@ -120,9 +120,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res

--- a/fomsub/bin/main.ml
+++ b/fomsub/bin/main.ml
@@ -122,9 +122,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res

--- a/fullequirec/bin/main.ml
+++ b/fullequirec/bin/main.ml
@@ -139,9 +139,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res

--- a/fullerror/bin/main.ml
+++ b/fullerror/bin/main.ml
@@ -138,9 +138,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res

--- a/fullfomsub/bin/main.ml
+++ b/fullfomsub/bin/main.ml
@@ -165,9 +165,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res

--- a/fullfsub/bin/main.ml
+++ b/fullfsub/bin/main.ml
@@ -156,9 +156,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res

--- a/fullisorec/bin/main.ml
+++ b/fullisorec/bin/main.ml
@@ -138,9 +138,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res

--- a/fullomega/bin/main.ml
+++ b/fullomega/bin/main.ml
@@ -162,9 +162,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res

--- a/fullpoly/bin/main.ml
+++ b/fullpoly/bin/main.ml
@@ -155,9 +155,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res

--- a/fullrecon/bin/main.ml
+++ b/fullrecon/bin/main.ml
@@ -127,9 +127,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res

--- a/fullref/bin/main.ml
+++ b/fullref/bin/main.ml
@@ -141,9 +141,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res

--- a/fullsimple/bin/main.ml
+++ b/fullsimple/bin/main.ml
@@ -139,9 +139,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res

--- a/fullsub/bin/main.ml
+++ b/fullsub/bin/main.ml
@@ -139,9 +139,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res

--- a/fulluntyped/bin/main.ml
+++ b/fulluntyped/bin/main.ml
@@ -113,9 +113,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res

--- a/fullupdate/bin/main.ml
+++ b/fullupdate/bin/main.ml
@@ -164,9 +164,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res

--- a/letexercise/bin/main.ml
+++ b/letexercise/bin/main.ml
@@ -119,9 +119,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res

--- a/purefsub/bin/main.ml
+++ b/purefsub/bin/main.ml
@@ -123,9 +123,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res

--- a/rcdsub/bin/main.ml
+++ b/rcdsub/bin/main.ml
@@ -119,9 +119,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res

--- a/recon/bin/main.ml
+++ b/recon/bin/main.ml
@@ -143,9 +143,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res

--- a/simplebool/bin/main.ml
+++ b/simplebool/bin/main.ml
@@ -120,9 +120,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res

--- a/tyarith/bin/main.ml
+++ b/tyarith/bin/main.ml
@@ -114,9 +114,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res

--- a/untyped/bin/main.ml
+++ b/untyped/bin/main.ml
@@ -110,9 +110,7 @@ let main () =
 let () = set_max_boxes 1000
 let () = set_margin 67
 let res = 
-  Printexc.catch (fun () -> 
     try main();0 
-    with Exit x -> x) 
-  ()
+    with Exit x -> x
 let () = print_flush()
 let () = exit res


### PR DESCRIPTION
Removed all occurrences of the Stdlib.Printexc.catch function along the files.