### PR TITLE
fix: printing of TmTimesfloat

### DIFF
--- a/fullequirec/lib/syntax.ml
+++ b/fullequirec/lib/syntax.ml
@@ -380,7 +380,7 @@ let rec printtm_Term outer ctx t = match t with
 
 and printtm_AppTerm outer ctx t = match t with
     TmTimesfloat(_,t1,t2) ->
-       pr "timesfloat "; printtm_ATerm false ctx t2; 
+       pr "timesfloat "; printtm_ATerm false ctx t1; 
        pr " "; printtm_ATerm false ctx t2
   | TmApp(fi, t1, t2) ->
       obox0();

--- a/fullfomsub/lib/syntax.ml
+++ b/fullfomsub/lib/syntax.ml
@@ -461,7 +461,7 @@ and printtm_AppTerm outer ctx t = match t with
   | TmIsZero(_,t1) ->
        pr "iszero "; printtm_ATerm false ctx t1
   | TmTimesfloat(_,t1,t2) ->
-       pr "timesfloat "; printtm_ATerm false ctx t2; 
+       pr "timesfloat "; printtm_ATerm false ctx t1; 
        pr " "; printtm_ATerm false ctx t2
   | t -> printtm_PathTerm outer ctx t
 

--- a/fullfsub/lib/syntax.ml
+++ b/fullfsub/lib/syntax.ml
@@ -410,7 +410,7 @@ and printtm_AppTerm outer ctx t = match t with
   | TmIsZero(_,t1) ->
        pr "iszero "; printtm_ATerm false ctx t1
   | TmTimesfloat(_,t1,t2) ->
-       pr "timesfloat "; printtm_ATerm false ctx t2; 
+       pr "timesfloat "; printtm_ATerm false ctx t1; 
        pr " "; printtm_ATerm false ctx t2
   | t -> printtm_PathTerm outer ctx t
 

--- a/fullisorec/lib/syntax.ml
+++ b/fullisorec/lib/syntax.ml
@@ -400,7 +400,7 @@ and printtm_AppTerm outer ctx t = match t with
       pr "unfold ["; printty_Type false ctx tyS; pr "]";
       cbox()
   | TmTimesfloat(_,t1,t2) ->
-       pr "timesfloat "; printtm_ATerm false ctx t2; 
+       pr "timesfloat "; printtm_ATerm false ctx t1; 
        pr " "; printtm_ATerm false ctx t2
   | TmPred(_,t1) ->
        pr "pred "; printtm_ATerm false ctx t1

--- a/fullomega/lib/syntax.ml
+++ b/fullomega/lib/syntax.ml
@@ -475,7 +475,7 @@ and printtm_AppTerm outer ctx t = match t with
        printtm_ATerm false ctx t1;
        cbox()
   | TmTimesfloat(_,t1,t2) ->
-       pr "timesfloat "; printtm_ATerm false ctx t2; 
+       pr "timesfloat "; printtm_ATerm false ctx t1; 
        pr " "; printtm_ATerm false ctx t2
   | TmPred(_,t1) ->
        pr "pred "; printtm_ATerm false ctx t1

--- a/fullpoly/lib/syntax.ml
+++ b/fullpoly/lib/syntax.ml
@@ -397,7 +397,7 @@ and printtm_AppTerm outer ctx t = match t with
   | TmIsZero(_,t1) ->
        pr "iszero "; printtm_ATerm false ctx t1
   | TmTimesfloat(_,t1,t2) ->
-       pr "timesfloat "; printtm_ATerm false ctx t2; 
+       pr "timesfloat "; printtm_ATerm false ctx t1; 
        pr " "; printtm_ATerm false ctx t2
   | t -> printtm_PathTerm outer ctx t
 

--- a/fullref/lib/syntax.ml
+++ b/fullref/lib/syntax.ml
@@ -421,7 +421,7 @@ and printtm_AppTerm outer ctx t = match t with
        printtm_ATerm false ctx t1;
        cbox()
   | TmTimesfloat(_,t1,t2) ->
-       pr "timesfloat "; printtm_ATerm false ctx t2; 
+       pr "timesfloat "; printtm_ATerm false ctx t1; 
        pr " "; printtm_ATerm false ctx t2
   | TmPred(_,t1) ->
        pr "pred "; printtm_ATerm false ctx t1

--- a/fullsimple/lib/syntax.ml
+++ b/fullsimple/lib/syntax.ml
@@ -372,7 +372,7 @@ let rec printtm_Term outer ctx t = match t with
 
 and printtm_AppTerm outer ctx t = match t with
     TmTimesfloat(_,t1,t2) ->
-       pr "timesfloat "; printtm_ATerm false ctx t2; 
+       pr "timesfloat "; printtm_ATerm false ctx t1; 
        pr " "; printtm_ATerm false ctx t2
   | TmApp(fi, t1, t2) ->
       obox0();

--- a/fullsub/lib/syntax.ml
+++ b/fullsub/lib/syntax.ml
@@ -340,7 +340,7 @@ let rec printtm_Term outer ctx t = match t with
 
 and printtm_AppTerm outer ctx t = match t with
     TmTimesfloat(_,t1,t2) ->
-       pr "timesfloat "; printtm_ATerm false ctx t2; 
+       pr "timesfloat "; printtm_ATerm false ctx t1; 
        pr " "; printtm_ATerm false ctx t2
   | TmApp(fi, t1, t2) ->
       obox0();

--- a/fulluntyped/lib/syntax.ml
+++ b/fulluntyped/lib/syntax.ml
@@ -219,7 +219,7 @@ and printtm_AppTerm outer ctx t = match t with
   | TmIsZero(_,t1) ->
        pr "iszero "; printtm_ATerm false ctx t1
   | TmTimesfloat(_,t1,t2) ->
-       pr "timesfloat "; printtm_ATerm false ctx t2; 
+       pr "timesfloat "; printtm_ATerm false ctx t1; 
        pr " "; printtm_ATerm false ctx t2
   | t -> printtm_PathTerm outer ctx t
 

--- a/fullupdate/lib/syntax.ml
+++ b/fullupdate/lib/syntax.ml
@@ -477,7 +477,7 @@ and printtm_AppTerm outer ctx t = match t with
   | TmIsZero(_,t1) ->
        pr "iszero "; printtm_ATerm false ctx t1
   | TmTimesfloat(_,t1,t2) ->
-       pr "timesfloat "; printtm_ATerm false ctx t2; 
+       pr "timesfloat "; printtm_ATerm false ctx t1; 
        pr " "; printtm_ATerm false ctx t2
   | t -> printtm_PathTerm outer ctx t
 


### PR DESCRIPTION
Printing of `TmTimesfloat` is wrong. It's printing twice the second term passed to the `timesfloat` expression. 

To reproduce execute the following code in the REPL. The output shows that the code is printing `1.` twice and doesn't print the `x`.
```
lambda x:Float. timesfloat x 1.0;
> (lambda x:Float. timesfloat 1. 1.) : Float -> Float
```